### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@
 # against bad commits.
 
 name: build
+permissions:
+  contents: read
 on: [pull_request, push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Ice129/My-World-Horror-Mod/security/code-scanning/1](https://github.com/Ice129/My-World-Horror-Mod/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow to restrict the default permissions associated with the `GITHUB_TOKEN` for this workflow/job. Since none of the listed steps in this workflow require write access to repository contents or other resources (the build only checks out code, sets up dependencies, builds, and uploads artifacts), the minimal required permission is `contents: read`. You can add the permissions block either at the root level (applies to all jobs) or to the individual job (`build`). Adding at the root level is preferred for clarity and future extensibility. Edit the `.github/workflows/build.yml` file by inserting the following block after the `name:` and before the `on:` key:

```yaml
permissions:
  contents: read
```

No imports or external packages are needed; just update the workflow YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
