### PR TITLE
Add Async Premine generation

### DIFF
--- a/src/main/java/horror/blueice129/command/DebugCommands.java
+++ b/src/main/java/horror/blueice129/command/DebugCommands.java
@@ -241,11 +241,7 @@ public class DebugCommands {
                                 .executes(context -> spawnFleeingEntity(context.getSource()))))
                         .then(literal("cave")
                             .then(literal("premine")
-                                .executes(context -> premineCave(context.getSource(), 1))
-                                .then(argument("attempts", IntegerArgumentType.integer(1, 10))
-                                    .executes(context -> premineCave(
-                                        context.getSource(),
-                                        IntegerArgumentType.getInteger(context, "attempts"))))))
+                                .executes(context -> premineCave(context.getSource()))))
                         .then(literal("visualize")
                             .then(literal("fov")
                                 .executes(context -> fillFieldOfViewWithGlass(context.getSource())))
@@ -1001,61 +997,24 @@ public class DebugCommands {
     /**
      * Pre-mine a cave near the player
      * @param source Command source
-     * @param attempts Number of attempts to find a suitable cave
      * @return Command success value
      */
-    private static int premineCave(ServerCommandSource source, int attempts) {
+    private static int premineCave(ServerCommandSource source) {
         ServerPlayerEntity player = source.getPlayer();
         if (player == null) {
             source.sendError(Text.literal("This command must be run by a player"));
             return 0;
         }
-        
-        if (attempts == 1) {
-            source.sendFeedback(() -> Text.literal("Attempting to pre-mine a cave..."), false);
-            boolean success = CavePreMiner.preMineCave(
+
+        source.sendFeedback(() -> Text.literal("Attempting to pre-mine a cave..."), false);
+        CavePreMiner.preMineCave(
                 player.getWorld(),
                 player.getBlockPos(),
                 player
-            );
-            
-            if (success) {
-                source.sendFeedback(() -> Text.literal("Successfully pre-mined a cave!"), false);
-                return Command.SINGLE_SUCCESS;
-            } else {
-                source.sendError(Text.literal("Failed to find a suitable cave. Try a different location."));
-                return 0;
-            }
-        } else {
-            source.sendFeedback(() -> Text.literal("Attempting to pre-mine a cave with " + attempts + " attempts..."), false);
-            
-            // Use a mutable wrapper class
-            class MutableResult {
-                public boolean success = false;
-                public int attempts = 0;
-            }
-            final MutableResult result = new MutableResult();
-            
-            for (int i = 0; i < attempts && !result.success; i++) {
-                result.attempts++;
-                result.success = CavePreMiner.preMineCave(
-                    player.getWorld(),
-                    player.getBlockPos(),
-                    player
-                );
-            }
-            
-            if (result.success) {
-                final int finalAttempts = result.attempts;
-                source.sendFeedback(() -> Text.literal("Successfully pre-mined a cave after " + finalAttempts + " attempt(s)!"), false);
-                return Command.SINGLE_SUCCESS;
-            } else {
-                source.sendError(Text.literal("Failed to find a suitable cave after " + attempts + " attempts"));
-                return 0;
-            }
-        }
+        );
+        return Command.SINGLE_SUCCESS;
     }
-    
+
     /**
      * Get the current smooth lighting state
      * @param source Command source

--- a/src/main/java/horror/blueice129/feature/CavePreMiner.java
+++ b/src/main/java/horror/blueice129/feature/CavePreMiner.java
@@ -1056,10 +1056,16 @@ public class CavePreMiner {
     public static void preMineCave(World world, BlockPos playerPos, PlayerEntity player) {
         Thread preMineThread = new Thread(() -> {
             boolean isFinished = false;
+            mainLoop:
             while (!isFinished) {
+                //check if player is spectator, dead or offline
+                if (player == null || (!player.isPartOfGame())) {
+                    break;
+                }
+
                 BlockPos starterPos = findStarterBlock(world, playerPos);
                 if (starterPos == null) {
-                    break;
+                    continue;
                 }
 
                 // Check if too close to existing pre-mined caves
@@ -1070,7 +1076,7 @@ public class CavePreMiner {
                 final int MIN_CAVE_DISTANCE_SQUARED = 100 * 100;
                 for (BlockPos existingCave : existingCaves) {
                     if (starterPos.getSquaredDistance(existingCave) < MIN_CAVE_DISTANCE_SQUARED) {
-                        break;
+                        continue mainLoop;
                     }
                 }
 
@@ -1082,7 +1088,7 @@ public class CavePreMiner {
                 int oresMined = result.oresMined;
 
                 if (caveAirBlocks.size() < 50) {
-                    break; // Not enough cave air blocks to consider this a cave
+                    continue; // Not enough cave air blocks to consider this a cave
                 }
 
                 int torchesPlaced = populateTorches(world, caveAirBlocks, player);
@@ -1098,7 +1104,7 @@ public class CavePreMiner {
             }
             HorrorMod129.LOGGER.info("Successfully pre-mined a cave!");
         });
-        preMineThread.setName("Pre-mine Thread for "+player.getName());
+        preMineThread.setName("Pre-mine Thread for "+player.getName().getString());
         preMineThread.start();
     }
 

--- a/src/main/java/horror/blueice129/feature/CavePreMiner.java
+++ b/src/main/java/horror/blueice129/feature/CavePreMiner.java
@@ -104,7 +104,7 @@ public class CavePreMiner {
      * 
      * @param world         The world to check in
      * @param pos           The position to check
-     * @param caveAirBlocks list of cave air blocks to check against
+     * @param caveAirSet list of cave air blocks to check against
      * @param player        The player to check line of sight against
      * @return True if the block is suitable, false otherwise
      */

--- a/src/main/java/horror/blueice129/feature/CavePreMiner.java
+++ b/src/main/java/horror/blueice129/feature/CavePreMiner.java
@@ -1098,6 +1098,7 @@ public class CavePreMiner {
             }
             HorrorMod129.LOGGER.info("Successfully pre-mined a cave!");
         });
+        preMineThread.setName("Pre-mine Thread for "+player.getName());
         preMineThread.start();
     }
 

--- a/src/main/java/horror/blueice129/feature/CavePreMiner.java
+++ b/src/main/java/horror/blueice129/feature/CavePreMiner.java
@@ -1053,45 +1053,52 @@ public class CavePreMiner {
      * @param player    The player entity
      * @return True if a cave was successfully pre-mined, false otherwise
      */
-    public static boolean preMineCave(World world, BlockPos playerPos, PlayerEntity player) {
-        BlockPos starterPos = findStarterBlock(world, playerPos);
-        if (starterPos == null) {
-            return false;
-        }
+    public static void preMineCave(World world, BlockPos playerPos, PlayerEntity player) {
+        Thread preMineThread = new Thread(() -> {
+            boolean isFinished = false;
+            while (!isFinished) {
+                BlockPos starterPos = findStarterBlock(world, playerPos);
+                if (starterPos == null) {
+                    break;
+                }
 
-        // Check if too close to existing pre-mined caves
-        ServerWorld serverWorld = (ServerWorld) world;
-        HorrorModPersistentState state = HorrorModPersistentState.getServerState(serverWorld.getServer());
-        java.util.List<BlockPos> existingCaves = state.getPositionList("preminedCaveLocations");
+                // Check if too close to existing pre-mined caves
+                ServerWorld serverWorld = (ServerWorld) world;
+                HorrorModPersistentState state = HorrorModPersistentState.getServerState(serverWorld.getServer());
+                java.util.List<BlockPos> existingCaves = state.getPositionList("preminedCaveLocations");
 
-        final int MIN_CAVE_DISTANCE_SQUARED = 100 * 100;
-        for (BlockPos existingCave : existingCaves) {
-            if (starterPos.getSquaredDistance(existingCave) < MIN_CAVE_DISTANCE_SQUARED) {
-                return false;
+                final int MIN_CAVE_DISTANCE_SQUARED = 100 * 100;
+                for (BlockPos existingCave : existingCaves) {
+                    if (starterPos.getSquaredDistance(existingCave) < MIN_CAVE_DISTANCE_SQUARED) {
+                        break;
+                    }
+                }
+
+                horror.blueice129.HorrorMod129.LOGGER.info("Cave Pre-Miner: Found starter block at " + starterPos);
+
+                // Combined cave exploration and ore mining in a single pass
+                CaveExplorationResult result = findCaveAirAndMineOres(world, starterPos, player);
+                java.util.List<BlockPos> caveAirBlocks = result.caveAirBlocks;
+                int oresMined = result.oresMined;
+
+                if (caveAirBlocks.size() < 50) {
+                    break; // Not enough cave air blocks to consider this a cave
+                }
+
+                int torchesPlaced = populateTorches(world, caveAirBlocks, player);
+                int extraBlocksPlaced = placeExtraBlocks(world, caveAirBlocks, player);
+                int stairLength = mineStairs(world, starterPos, player);
+
+                // Store this cave location to prevent future caves from being too close
+                state.addPositionToList("preminedCaveLocations", starterPos);
+
+                HorrorMod129.LOGGER.info("Cave Pre-Miner: Mined " + oresMined + " ores, placed " + torchesPlaced
+                        + " torches, extra blocks placed: " + extraBlocksPlaced + ", stair length: " + stairLength);
+                isFinished = true;
             }
-        }
-
-        horror.blueice129.HorrorMod129.LOGGER.info("Cave Pre-Miner: Found starter block at " + starterPos);
-
-        // Combined cave exploration and ore mining in a single pass
-        CaveExplorationResult result = findCaveAirAndMineOres(world, starterPos, player);
-        java.util.List<BlockPos> caveAirBlocks = result.caveAirBlocks;
-        int oresMined = result.oresMined;
-
-        if (caveAirBlocks.size() < 50) {
-            return false; // Not enough cave air blocks to consider this a cave
-        }
-
-        int torchesPlaced = populateTorches(world, caveAirBlocks, player);
-        int extraBlocksPlaced = placeExtraBlocks(world, caveAirBlocks, player);
-        int stairLength = mineStairs(world, starterPos, player);
-
-        // Store this cave location to prevent future caves from being too close
-        state.addPositionToList("preminedCaveLocations", starterPos);
-
-        HorrorMod129.LOGGER.info("Cave Pre-Miner: Mined " + oresMined + " ores, placed " + torchesPlaced
-                + " torches, extra blocks placed: " + extraBlocksPlaced + ", stair length: " + stairLength);
-        return true;
+            HorrorMod129.LOGGER.info("Successfully pre-mined a cave!");
+        });
+        preMineThread.start();
     }
 
 }

--- a/src/main/java/horror/blueice129/mixin/BodyControlMixin.java
+++ b/src/main/java/horror/blueice129/mixin/BodyControlMixin.java
@@ -1,0 +1,30 @@
+package horror.blueice129.mixin;
+
+import horror.blueice129.entity.Blueice129Entity;
+import net.minecraft.entity.ai.control.BodyControl;
+import net.minecraft.entity.mob.MobEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(BodyControl.class)
+public abstract class BodyControlMixin {
+    @Shadow
+    @Final
+    private MobEntity entity;
+
+    @Shadow
+    protected abstract void slowlyAdjustBody();
+
+    @Redirect(
+            method = "tick",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/control/BodyControl;slowlyAdjustBody()V")
+    )
+    private void redirectSlowBodyAdjustment(BodyControl instance) {
+        if (!(entity instanceof Blueice129Entity)) {
+            slowlyAdjustBody();
+        }
+    }
+}

--- a/src/main/java/horror/blueice129/scheduler/CaveMinerScheduler.java
+++ b/src/main/java/horror/blueice129/scheduler/CaveMinerScheduler.java
@@ -73,14 +73,7 @@ public class CaveMinerScheduler {
             // If the timer has reached zero
             if (currentTimer <= 0) {
                 // Trigger the cave miner event
-                while (!CavePreMiner.preMineCave(player.getWorld(), player.getBlockPos(), player)) {
-                    // If unsuccessful, set a short retry delay
-                    int retryDelay = 1200; // 1 minute
-                    state.setTimer(TIMER_ID, retryDelay);
-                    HorrorMod129.LOGGER.info("CavePreMiner attempt failed, retrying in 1 minute.");
-                    return;
-                }
-                HorrorMod129.LOGGER.info("CavePreMiner event executed successfully.");
+                CavePreMiner.preMineCave(player.getWorld(), player.getBlockPos(), player);
 
                 // Reset the timer with a new random delay
                 state.setTimer(TIMER_ID, getRandomDelay());

--- a/src/main/resources/horror-mod-129.mixins.json
+++ b/src/main/resources/horror-mod-129.mixins.json
@@ -1,22 +1,23 @@
 {
-	"required": true,
-	"package": "horror.blueice129.mixin",
-	"compatibilityLevel": "JAVA_17",
-	"mixins": [
-		"ExampleMixin",
-		"ServerWorldSleepStatusMixin",
-		"SleepManagerMixin"
-	],
-	"client": [
-		"client.GameRendererAccessor",
-		"client.GameRendererMixin",
-		"client.MinecraftClientAccessor",
-		"client.PlayerEntityAccessor"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	},
-	"overwrites": {
-		"requireAnnotations": true
+  "required": true,
+  "package": "horror.blueice129.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "BodyControlMixin",
+    "ExampleMixin",
+    "ServerWorldSleepStatusMixin",
+    "SleepManagerMixin"
+  ],
+  "client": [
+    "client.GameRendererAccessor",
+    "client.GameRendererMixin",
+    "client.MinecraftClientAccessor",
+    "client.PlayerEntityAccessor"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
 	}
 }


### PR DESCRIPTION
I was playing around a bit, and noticed that the mine generation sometimes lagged the game quite a bit, which kinda ruined the immersion a bit.

As such, I made it so when the timer for scheduling a premine runs out, it makes a new thread to constantly check for eligible positions, and when it finds such it creates the mine and then ends itself. This not only eliminates the lag, but also makes mine generation faster and closer to where the timer originally went off.

Although it is a bit of a brute method, it shouldn't cause any issues, since most of the lifetime of the thread is spent reading data and only in the end does it write (and does so on a relatively small number of blocks relatively quickly), which means that thread sync errors shouldn't (?) occur.